### PR TITLE
Version 49.0 - weaker dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+gnome-shell-ubuntu-extensions (49.0) questing; urgency=medium
+
+  * Update for GNOME Shell 49 and later, removing strict version requirements
+    already enforced in the individual extensions. It doesn't make sense to
+    have to bump the dependencies here too.
+
+ -- Daniel van Vugt <daniel.van.vugt@canonical.com>  Wed, 16 Jul 2025 13:26:45 +0800
+
 gnome-shell-ubuntu-extensions (48.0) plucky; urgency=medium
 
   * Update for GNOME Shell 48

--- a/debian/control
+++ b/debian/control
@@ -13,12 +13,10 @@ Homepage: https://github.com/ubuntu/gnome-shell-ubuntu-extensions
 
 Package: gnome-shell-ubuntu-extensions
 Architecture: all
-Depends: gnome-shell (<< ${gnome:NextVersion}),
-         gnome-shell (>= ${gnome:Version}),
-         gnome-shell-extension-appindicator (>= 59-3~),
-         gnome-shell-extension-desktop-icons-ng (>= 47.0.13-1~),
-         gnome-shell-extension-ubuntu-tiling-assistant (>= 50-1ubuntu1~),
-         gnome-shell-extension-ubuntu-dock (>= 99ubuntu3~),
+Depends: gnome-shell-extension-appindicator,
+         gnome-shell-extension-desktop-icons-ng,
+         gnome-shell-extension-ubuntu-tiling-assistant,
+         gnome-shell-extension-ubuntu-dock,
          ${misc:Depends}
 Suggests: gnome-shell-extension-prefs
 Description: Ubuntu official Extensions to extend functionality of GNOME Shell


### PR DESCRIPTION
Update for GNOME Shell 49 and later, removing strict version requirements already enforced in the individual extensions. It doesn't make sense to have to bump the dependencies here too.