### PR TITLE
debian/lrc.config: Exclude appindicators patches

### DIFF
--- a/debian/lrc.config
+++ b/debian/lrc.config
@@ -1,0 +1,18 @@
+# licenserecon
+#
+# This file lists files and directories to be excluded from checking, to avoid
+# false positives.
+#
+# Lines starting with # are treated as comments. Blank lines are ignored.
+# Lines starting with minus sign(s) are treated as command line options
+#
+# File names may include a partial path.
+#
+# Wildcards '*' are not supported.
+#
+# For directories identified by trailing slash / the entire contents will be
+# (recursively) excluded.
+
+# Contains false positives
+subprojects/packagefiles/patches/appindicators/
+


### PR DESCRIPTION
Exclude the `subprojects/packagefiles/patches/appindicators/` directory from licenserecon checks because its license is identified incorrectly.

Context: We're about to merge https://github.com/canonical/desktop-engineering/pull/97 which runs lrc as part of the build-deb action.