### PR TITLE
Update to DING 49.99.0

### DIFF
--- a/subprojects/desktop-icons-ng.wrap
+++ b/subprojects/desktop-icons-ng.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory = desktop-icons-ng
 url = https://gitlab.com/rastersoft/desktop-icons-ng.git
-revision = 49.0.5
+revision = 49.99.0
 depth = 1


### PR DESCRIPTION
Ubuntu 26.04 has Gnome Shell 50, which is supported in DING 49.99.0.