### PR TITLE
Update DING to 49.99.1

### DIFF
--- a/subprojects/desktop-icons-ng.wrap
+++ b/subprojects/desktop-icons-ng.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory = desktop-icons-ng
 url = https://gitlab.com/rastersoft/desktop-icons-ng.git
-revision = 49.99.0
+revision = 49.99.1
 depth = 1


### PR DESCRIPTION
This version supports changing the icon size using the keyboard, and one extra translation.