### PR TITLE
Update DING to version 50.0.0

### DIFF
--- a/subprojects/desktop-icons-ng.wrap
+++ b/subprojects/desktop-icons-ng.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory = desktop-icons-ng
 url = https://gitlab.com/rastersoft/desktop-icons-ng.git
-revision = 49.99.1
+revision = 50.0.0
 depth = 1


### PR DESCRIPTION
This change fixes the desktop window not having a size before calling show_all(), and thus not showing the icons in some cases.