### PR TITLE
subprojects/dash-to-dock: fix translation installation

### DIFF
--- a/subprojects/packagefiles/dash-to-dock/meson.build
+++ b/subprojects/packagefiles/dash-to-dock/meson.build
@@ -4,32 +4,49 @@ make = find_program('make')
 d2d_src = meson.current_source_dir()
 
 prefix = get_option('prefix')
-meson.add_install_script(make, '-C', d2d_src, 'install', 'PREFIX="@0@"'.format(
-    prefix))
+share_dir = prefix / get_option('datadir')
 
 sh = find_program('sh')
-
-if prefix != '/usr'
-    meson.add_install_script(sh, '-xue', '-c',
-        ';'.join([
-            'mkdir -p "${DESTDIR}/@0@"',
-            'cp -RT "${DESTDIR}"/usr/share ${DESTDIR}/@0@/@1@',
-            'rm -rf "${DESTDIR}"/usr/share',
-        ]).format(prefix, get_option('datadir')))
-endif
+glib_compile_schemas = find_program('glib-compile-schemas')
 
 jq = find_program('jq', required: true)
 metadata = files('metadata.json')
 
-uuid = run_command(jq, '-r', '."uuid"', metadata).stdout().strip()
+uuid = run_command(jq, '-r', '."uuid" // empty', metadata, check: true).stdout().strip()
+if uuid == ''
+    error('metadata.json must define a non-empty "uuid"')
+endif
+extension_install_dir = share_dir / 'gnome-shell' / 'extensions' / uuid
+locale_install_dir = prefix == '/usr' ? share_dir / 'locale' : extension_install_dir / 'locale'
 
 meson.add_install_script(sh, '-xue', '-c',
     ';'.join([
-        'mkdir -p ${DESTDIR}/@1@',
-        'cp @0@/ubuntu.css ${DESTDIR}/@1@',
+        'source_dir="@0@"',
+        'install_root="${DESTDIR:-}"',
+        'make_destdir="$install_root"',
+        'if [ -z "$make_destdir" ] || [ "@5@" != "/usr" ]; then make_destdir="$(mktemp -d)"; trap \'rm -rf "$make_destdir"\' EXIT; fi',
+        'extension_install_dir="$install_root@2@"',
+        'staged_extension_dir="$make_destdir/usr/share/gnome-shell/extensions/@6@"',
+        'staged_schema_dir="$make_destdir/usr/share/glib-2.0/schemas"',
+        'system_schema_dir="$install_root@1@/glib-2.0/schemas"',
+        '"@3@" -C "$source_dir" install DESTDIR="$make_destdir"',
+        'if [ "$make_destdir" != "$install_root" ]; then mkdir -p "$(dirname "$extension_install_dir")"; cp -RT "$staged_extension_dir" "$extension_install_dir"; fi',
+        'if [ "@5@" = "/usr" ] && [ "$make_destdir" != "$install_root" ] && [ -d "$staged_schema_dir" ]; then mkdir -p "$system_schema_dir"; cp -R "$staged_schema_dir"/. "$system_schema_dir"/; fi',
+        'mkdir -p "$extension_install_dir"',
+        'cp "$source_dir/ubuntu.css" "$extension_install_dir"',
+        'mkdir -p "$extension_install_dir/schemas"',
+        'cp "$source_dir"/schemas/*.xml "$extension_install_dir/schemas"',
+        'cp "$source_dir"/schemas/*.gschema.override "$extension_install_dir/schemas"',
+        '"@4@" "$extension_install_dir/schemas"',
+        'rm -f "$extension_install_dir/schemas/"*.gschema.override',
     ]).format(
         meson.current_source_dir(),
-        prefix / get_option('datadir') / 'gnome-shell' / 'extensions' / uuid,
+        share_dir,
+        extension_install_dir,
+        make.full_path(),
+        glib_compile_schemas.full_path(),
+        prefix,
+        uuid,
     ))
 
 test('linting',

--- a/subprojects/packagefiles/dash-to-dock/po/meson.build
+++ b/subprojects/packagefiles/dash-to-dock/po/meson.build
@@ -5,9 +5,15 @@ languages = run_command(sh, '-ex', '-c',
     'for i in *.po; do basename "$i" .po; done',
     check: true, capture: true).stdout().strip().split('\n')
 
-gettext_domain = run_command(jq, '-r', '."gettext-domain"', metadata).stdout().strip()
+gettext_domain = run_command(
+    jq, '-r', '."gettext-domain" // empty', metadata,
+    check: true,
+).stdout().strip()
 
 assert(languages.length() > 0)
+if gettext_domain == ''
+    error('metadata.json must define a non-empty "gettext-domain"')
+endif
 i18n.gettext(gettext_domain,
     args: [
         '--keyword=__',
@@ -15,6 +21,6 @@ i18n.gettext(gettext_domain,
         '--from-code=utf-8',
         '--add-comments=Translators:',
     ],
-    install: false,
+    install_dir: locale_install_dir,
     languages: languages,
 )


### PR DESCRIPTION
This fixes Dash to Dock translations not getting installed.

The packaging step already moved the extension files into the layout we want, but the translation files were getting lost along the way. This updates the install flow so we stage the upstream install output first, then copy both the extension files and locale files into the final package layout.
