### PR TITLE
tools/validate-wrap-revisions: Require tags to come with a SHA revision

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -10,6 +10,8 @@ single point of control of their versions (the ./subprojects/*.wrap files).
  - Each wrap file must point to the extension git repository (or ubuntu fork)
  - Wrap files MUST reference a specific `revision` that points to an upstream
    git tag or commit SHA. Branch names or HEAD are not valid values.
+   If a tag is used, the custom field `x_revision_sha` must also be provided
+   to prevent any potential supply-chain attack.
    This is ensured by a CI job.
  - Patches can be added using the wrap system in:
    - subprojects/packagefiles/patches/<extension>/*.patch

--- a/debian/rules
+++ b/debian/rules
@@ -41,3 +41,4 @@ override_dh_translations:
 update-subprojects:
 	meson subprojects purge --confirm
 	meson subprojects download
+	tools/validate-wrap-revisions.py

--- a/subprojects/dash-to-dock.wrap
+++ b/subprojects/dash-to-dock.wrap
@@ -2,5 +2,6 @@
 directory = dash-to-dock
 url = https://github.com/micheleg/dash-to-dock.git
 revision = ubuntu-dock-104ubuntu1
+x_revision_sha = 2ab678fa5adec430c38fd005895afb1bcaf25503
 depth = 1
 patch_directory = dash-to-dock

--- a/subprojects/snapd-prompting.wrap
+++ b/subprojects/snapd-prompting.wrap
@@ -2,5 +2,5 @@
 directory = snapd-prompting
 url = https://gitlab.gnome.org/Community/Ubuntu/gnome-shell-extension-snapd-prompting.git
 revision = v2
+x_revision_sha = 7cf23b537f453e9b277e034d32feba849e1fb341
 depth = 1
-

--- a/subprojects/snapd-search-provider.wrap
+++ b/subprojects/snapd-search-provider.wrap
@@ -2,5 +2,6 @@
 directory = snapd-search-provider
 url = https://gitlab.gnome.org/Community/Ubuntu/gnome-shell-snapd-search-provider.git
 revision = v2
+x_revision_sha = 112c0dbf30b517137b9b3391fa47e791c40ae646
 depth = 1
 

--- a/subprojects/web-search-provider.wrap
+++ b/subprojects/web-search-provider.wrap
@@ -2,5 +2,5 @@
 directory = web-search-provider
 url = https://gitlab.gnome.org/Community/Ubuntu/gnome-shell-web-search-provider.git
 revision = v2
+x_revision_sha = b39947e391bc2100ff4cd2b917e58c3a17a60d3d
 depth = 1
-

--- a/tools/validate-wrap-revisions.py
+++ b/tools/validate-wrap-revisions.py
@@ -14,19 +14,21 @@ SHA1_RE = re.compile(r'^[0-9a-f]{7,40}$', re.I)
 def ls_remote_tags(url):
     out = subprocess.check_output(['git', 'ls-remote', '--tags', url],
                                   stderr=subprocess.DEVNULL, timeout=30)
-    tags = set()
+    tags = {}  # tag name -> commit SHA
     for line in out.splitlines():
         parts = line.decode('utf-8').split('\t', 1)
         if len(parts) != 2:
             continue
-        _, ref = parts
+        sha, ref = parts
         if not ref.startswith('refs/tags/'):
             continue
         # Annotated tags end with ^{}
         if ref.endswith('^{}'):
-            tags.add(ref[len('refs/tags/'):-3])
+            tags[ref[len('refs/tags/'):-3]] = sha.strip()
         else:
-            tags.add(ref[len('refs/tags/'):])
+            tag = ref[len('refs/tags/'):]
+            if tag not in tags:
+                tags[tag] = sha.strip()
     return tags
 
 
@@ -45,7 +47,17 @@ def validate_wrap_file(path):
     if not rev:
         return False, [f'{path}: missing revision']
 
+    revision_tag = section.get('x_revision_tag')
+
     if SHA1_RE.match(rev):
+        if revision_tag:
+            tags = ls_remote_tags(url)
+            tag_sha = tags.get(revision_tag)
+            if tag_sha is None:
+                return False, [f'{path}: x_revision_tag "{revision_tag}" not found in remote {url}']
+            if not tag_sha.startswith(rev) and not rev.startswith(tag_sha):
+                return False, [f'{path}: x_revision_tag "{revision_tag}" resolves to {tag_sha}, '
+                               f'but revision is {rev}']
         return True, []
 
     tags = ls_remote_tags(url)
@@ -57,6 +69,9 @@ def validate_wrap_file(path):
         return False, [f'{path}: revision "{rev}" not found among tags in remote ' +
                        f'{url} (available tags: {sorted(list(tags))[:10]}...). ' +
                        'Note: branch names are not accepted.']
+
+    if revision_tag and revision_tag != rev:
+        return False, [f'{path}: x_revision_tag "{revision_tag}" does not match revision tag "{rev}"']
 
     return True, []
 

--- a/tools/validate-wrap-revisions.py
+++ b/tools/validate-wrap-revisions.py
@@ -48,6 +48,7 @@ def validate_wrap_file(path):
         return False, [f'{path}: missing revision']
 
     revision_tag = section.get('x_revision_tag')
+    revision_sha = section.get('x_revision_sha')
 
     if SHA1_RE.match(rev):
         if revision_tag:
@@ -72,6 +73,16 @@ def validate_wrap_file(path):
 
     if revision_tag and revision_tag != rev:
         return False, [f'{path}: x_revision_tag "{revision_tag}" does not match revision tag "{rev}"']
+
+    if not revision_sha:
+        return False, [f'{path}: x_revision_sha is required when revision is a tag name']
+
+    tag_sha = tags.get(rev)
+    if not tag_sha:
+        return False, [f'{path}: could not resolve SHA for tag "{rev}"']
+    if not tag_sha.startswith(revision_sha) and not revision_sha.startswith(tag_sha):
+        return False, [f'{path}: x_revision_sha "{revision_sha}" does not match '
+                       f'SHA of tag "{rev}" ({tag_sha})']
 
     return True, []
 


### PR DESCRIPTION
Even though we control most of the upstream repositories, we do not want
to end up in a situation in which a tag changes without being aware of
that, potentially causing a supply-chain attack.

So let's support tags, but if this is the case, then they must come with
a related SHA.