### PR TITLE
Update to DING 51.0.3

### DIFF
--- a/subprojects/desktop-icons-ng.wrap
+++ b/subprojects/desktop-icons-ng.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory = desktop-icons-ng
-url = https://salsa.debian.org/ubuntu-dev-team/desktop-icons-ng.git
-revision = f16a47af267b8c10f339913354ed9d8c83b63807
+url = https://salsa.debian.org/gnome-team/shell-extensions/gnome-shell-extension-desktop-icons-ng.git
+revision = 9dcda310fecf9da6367e28df4bf97afb543d8387
 depth = 1


### PR DESCRIPTION
This is the new version with Gtk4 support and use of the DESKTOP window type.

But there seems to be a bug in Debian Testing/SID (which uses mutter 50.2) that crashes mutter when switching into a configuration with less monitors that before (for example, when going from "Joined desktops" to "Use only external monitor"). This bug usually isn't noticed because it is only triggered when there is a DESKTOP-tagged window (checked both with DING 50 and with DING-Gtk4 from Sundeep Mediratta): removing the line that adds the "DESKTOP" flag to the DING windows "fixes" the problem.

It doesn't happen in Ubuntu (mutter 50.1), nor in Fedora 44 (mutter 50.3), so it's either something specific to Debian, or to mutter 50.2. We should keep an eye on that.